### PR TITLE
Allow use debug component with ESP32 C2

### DIFF
--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -8,6 +8,8 @@
 
 #if defined(USE_ESP32_VARIANT_ESP32)
 #include <esp32/rom/rtc.h>
+#elif defined(USE_ESP32_VARIANT_ESP32C2)
+#include <esp32c2/rom/rtc.h>
 #elif defined(USE_ESP32_VARIANT_ESP32C3)
 #include <esp32c3/rom/rtc.h>
 #elif defined(USE_ESP32_VARIANT_ESP32C6)
@@ -57,9 +59,11 @@ std::string DebugComponent::get_reset_reason_() {
     case TG0WDT_SYS_RESET:
       reset_reason = "Timer Group 0 Watch Dog Reset Digital Core";
       break;
+#if !defined(USE_ESP32_VARIANT_ESP32C2)    
     case TG1WDT_SYS_RESET:
       reset_reason = "Timer Group 1 Watch Dog Reset Digital Core";
       break;
+#endif    
     case RTCWDT_SYS_RESET:
       reset_reason = "RTC Watch Dog Reset Digital Core";
       break;
@@ -170,6 +174,8 @@ void DebugComponent::get_device_info_(std::string &device_info) {
   const char *model;
 #if defined(USE_ESP32_VARIANT_ESP32)
   model = "ESP32";
+#elif defined(USE_ESP32_VARIANT_ESP32C2)
+  model = "ESP32-C2";  
 #elif defined(USE_ESP32_VARIANT_ESP32C3)
   model = "ESP32-C3";
 #elif defined(USE_ESP32_VARIANT_ESP32C6)
@@ -256,9 +262,11 @@ void DebugComponent::get_device_info_(std::string &device_info) {
     case UART1_TRIG:
       wakeup_reason = "UART1";
       break;
+#if !defined(USE_ESP32_VARIANT_ESP32C2)    
     case TOUCH_TRIG:
       wakeup_reason = "Touch";
       break;
+#endif    
     case SAR_TRIG:
       wakeup_reason = "SAR";
       break;


### PR DESCRIPTION
# What does this implement/fix?

Can't compile firmware with debug component for ESP32 C2 

```
Compiling .pioenvs/kotel-esp32-c2/src/esphome/components/debug/debug_component.cpp.o
Compiling .pioenvs/kotel-esp32-c2/src/esphome/components/debug/debug_esp32.cpp.o
Compiling .pioenvs/kotel-esp32-c2/src/esphome/components/debug/debug_esp8266.cpp.o
Compiling .pioenvs/kotel-esp32-c2/src/esphome/components/debug/debug_host.cpp.o
src/esphome/components/debug/debug_esp32.cpp: In member function 'std::string esphome::debug::DebugComponent::get_reset_reason_()':
src/esphome/components/debug/debug_esp32.cpp:33:11: error: 'rtc_get_reset_reason' was not declared in this scope; did you mean 'get_reset_reason_'?
   33 |   switch (rtc_get_reset_reason(0)) {
      |           ^~~~~~~~~~~~~~~~~~~~
      |           get_reset_reason_
src/esphome/components/debug/debug_esp32.cpp:34:10: error: 'POWERON_RESET' was not declared in this scope; did you mean 'ECONNRESET'?
   34 |     case POWERON_RESET:
      |          ^~~~~~~~~~~~~
      |          ECONNRESET
src/esphome/components/debug/debug_esp32.cpp:49:10: error: 'DEEPSLEEP_RESET' was not declared in this scope
   49 |     case DEEPSLEEP_RESET:
      |          ^~~~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:57:10: error: 'TG0WDT_SYS_RESET' was not declared in this scope
   57 |     case TG0WDT_SYS_RESET:
      |          ^~~~~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:60:10: error: 'TG1WDT_SYS_RESET' was not declared in this scope
   60 |     case TG1WDT_SYS_RESET:
      |          ^~~~~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:63:10: error: 'RTCWDT_SYS_RESET' was not declared in this scope
   63 |     case RTCWDT_SYS_RESET:
      |          ^~~~~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:67:10: error: 'INTRUSION_RESET' was not declared in this scope
   67 |     case INTRUSION_RESET:
      |          ^~~~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:87:10: error: 'RTCWDT_CPU_RESET' was not declared in this scope
   87 |     case RTCWDT_CPU_RESET:
      |          ^~~~~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:95:10: error: 'RTCWDT_BROWN_OUT_RESET' was not declared in this scope
   95 |     case RTCWDT_BROWN_OUT_RESET:
      |          ^~~~~~~~~~~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:98:10: error: 'RTCWDT_RTC_RESET' was not declared in this scope
   98 |     case RTCWDT_RTC_RESET:
      |          ^~~~~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp: In member function 'void esphome::debug::DebugComponent::get_device_info_(std::string&)':
src/esphome/components/debug/debug_esp32.cpp:231:11: error: 'rtc_get_wakeup_cause' was not declared in this scope
  231 |   switch (rtc_get_wakeup_cause()) {
      |           ^~~~~~~~~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:232:10: error: 'NO_SLEEP' was not declared in this scope
  232 |     case NO_SLEEP:
      |          ^~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:235:10: error: 'EXT_EVENT0_TRIG' was not declared in this scope
  235 |     case EXT_EVENT0_TRIG:
      |          ^~~~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:238:10: error: 'EXT_EVENT1_TRIG' was not declared in this scope
  238 |     case EXT_EVENT1_TRIG:
      |          ^~~~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:241:10: error: 'GPIO_TRIG' was not declared in this scope
  241 |     case GPIO_TRIG:
      |          ^~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:244:10: error: 'TIMER_EXPIRE' was not declared in this scope
  244 |     case TIMER_EXPIRE:
      |          ^~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:247:10: error: 'SDIO_TRIG' was not declared in this scope
  247 |     case SDIO_TRIG:
      |          ^~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:250:10: error: 'MAC_TRIG' was not declared in this scope
  250 |     case MAC_TRIG:
      |          ^~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:253:10: error: 'UART0_TRIG' was not declared in this scope
  253 |     case UART0_TRIG:
      |          ^~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:256:10: error: 'UART1_TRIG' was not declared in this scope
  256 |     case UART1_TRIG:
      |          ^~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:259:10: error: 'TOUCH_TRIG' was not declared in this scope
  259 |     case TOUCH_TRIG:
      |          ^~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:262:10: error: 'SAR_TRIG' was not declared in this scope
  262 |     case SAR_TRIG:
      |          ^~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:265:10: error: 'BT_TRIG' was not declared in this scope
  265 |     case BT_TRIG:
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
esp32:
  board: esp32-c2-devkitm-1
  variant: esp32c2
  flash_size: 4MB  
  framework:
    type: esp-idf
    platform_version: "https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF5"
    version: 5.1.4
    source: https://github.com/tasmota/esp-idf/releases/download/v5.1.4.240912/esp-idf-v5.1.4.zip
    sdkconfig_options:
      CONFIG_XTAL_FREQ_26: y  
      CONFIG_ESPTOOLPY_FLASHSIZE_4MB: y
      CONFIG_IDF_TARGET_ESP32C2: y

 debug:
   update_interval: 5s

sensor:
  - platform: debug
    free:
      name: "Heap Free"
      id: heap_free   
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
